### PR TITLE
Fix mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Install the theme with the following commands
 
 If you want to install the latest version from git, clone the repository with
 
-    git clone https://github.com/eti1337/arc-theme-orange.git --depth 1 && cd arc-theme
+    git clone https://github.com/eti1337/arc-theme-orange.git --depth 1 && cd arc-theme-orange
 
 **2. Build and install the theme**
 


### PR DESCRIPTION
When you clone the repo, you get a folder which name is arc-theme-orange instead of arc-theme
